### PR TITLE
feat: add file-core read-only prototype

### DIFF
--- a/PHASE.yml
+++ b/PHASE.yml
@@ -1,9 +1,17 @@
-phase: "02_INVENTORY"
+phase: "03_FILE_CORE_READONLY"
 allowed_paths:
-  - tools/inventory.md
+  - PHASE.yml
+  - tools/check_phase.mjs
+  - .github/workflows/ci.yml
+  - packages/model/**
+  - packages/fs-adapter/**
+  - packages/file-core/**
+  - tools/fixtures/**
+  - pnpm-workspace.yaml
+  - tsconfig.base.json
 acceptance:
   - pnpm -w build
-  - pnpm -w lint
   - pnpm -w test
+  - pnpm -w lint
   - pnpm -w typecheck
 ts_strict_required: true

--- a/packages/file-core/package.json
+++ b/packages/file-core/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@logseq/file-core",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test dist/test/read.spec.js"
+  },
+  "dependencies": {
+    "@logseq/model": "workspace:*",
+    "@logseq/fs-adapter": "workspace:*"
+  }
+}

--- a/packages/file-core/src/core.ts
+++ b/packages/file-core/src/core.ts
@@ -1,0 +1,43 @@
+import type { FsAdapter } from '@logseq/fs-adapter';
+import { Backlink } from '@logseq/model';
+import { parseFile } from './parse.js';
+import { InMemoryFileCore, Indices } from './read.js';
+
+export async function createFileCore(root: string, adapter: FsAdapter) {
+  const files = await adapter.listFiles(root);
+  const mdFiles = files.filter((f: string) => f.endsWith('.md'));
+  const indices: Indices = {
+    pageByTitle: new Map(),
+    blocksById: new Map(),
+    childrenByParent: new Map(),
+    backlinks: new Map()
+  };
+  const backlinkPairs: Array<{ key: string; value: Backlink }> = [];
+
+  for (const file of mdFiles) {
+    const content = await adapter.readFile(file);
+    const parsed = parseFile(file, content);
+    indices.pageByTitle.set(parsed.page.title, parsed.page);
+    const pageKey = `page:${parsed.page.title}`;
+    indices.childrenByParent.set(pageKey, []);
+    for (const block of parsed.blocks) {
+      indices.blocksById.set(block.id, block);
+      const parent = block.parentId ?? pageKey;
+      if (!indices.childrenByParent.has(parent)) {
+        indices.childrenByParent.set(parent, []);
+      }
+      indices.childrenByParent.get(parent)!.push(block.id);
+      for (const link of block.links) {
+        const key = link.type === 'page' ? `page:${link.page}` : `block:${link.blockId}`;
+        backlinkPairs.push({ key, value: { sourcePage: block.pageId, sourceBlockId: block.id } });
+      }
+    }
+  }
+
+  for (const { key, value } of backlinkPairs) {
+    if (!indices.backlinks.has(key)) indices.backlinks.set(key, []);
+    indices.backlinks.get(key)!.push(value);
+  }
+
+  return new InMemoryFileCore(indices);
+}

--- a/packages/file-core/src/errors.ts
+++ b/packages/file-core/src/errors.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/packages/file-core/src/index.ts
+++ b/packages/file-core/src/index.ts
@@ -1,0 +1,3 @@
+export { createFileCore } from './core.js';
+export { watchGraph } from './watch.js';
+export type { FileCore } from './read.js';

--- a/packages/file-core/src/parse.ts
+++ b/packages/file-core/src/parse.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { Block, Link, Page } from '@logseq/model';
+
+export interface ParsedData {
+  page: Page;
+  blocks: Block[];
+}
+
+const pageLinkRe = /\[\[([^\]]+)\]\]/g;
+const blockLinkRe = /\(\(([^)]+)\)\)/g;
+
+export function parseFile(filePath: string, content: string): ParsedData {
+  const lines = content.split(/\r?\n/);
+  const filename = path.basename(filePath, path.extname(filePath));
+  let title = filename;
+  const blocks: Block[] = [];
+  const stack: Array<{ indent: number; id: string }> = [];
+  let counter = 0;
+
+  for (const raw of lines) {
+    if (!raw.trim()) continue;
+    const prop = raw.match(/^([A-Za-z0-9_-]+)::\s*(.+)$/);
+    if (prop && !raw.trimStart().startsWith('-')) {
+      if (prop[1] === 'title') title = prop[2].trim();
+      continue;
+    }
+    const m = raw.match(/^(\s*)-\s+(.*)$/);
+    if (!m) continue;
+    const indent = m[1].length;
+    let text = m[2];
+    let idMatch = text.match(/^id::\s*(\S+)\s*(.*)$/);
+    let id = '';
+    if (idMatch) {
+      id = idMatch[1];
+      text = idMatch[2];
+    }
+    const links: Link[] = [];
+    let l: RegExpExecArray | null;
+    while ((l = pageLinkRe.exec(text))) {
+      links.push({ type: 'page', page: l[1] });
+    }
+    while ((l = blockLinkRe.exec(text))) {
+      links.push({ type: 'block', blockId: l[1] });
+    }
+    if (!id) {
+      counter += 1;
+      id = `${filename}-${counter}`;
+    }
+    while (stack.length && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+    const parentId = stack.length ? stack[stack.length - 1].id : null;
+    const block: Block = { id, pageId: title, parentId, text: text.trim(), links };
+    blocks.push(block);
+    stack.push({ indent, id });
+  }
+
+  const page: Page = { id: title, title, path: filePath };
+  return { page, blocks };
+}

--- a/packages/file-core/src/read.ts
+++ b/packages/file-core/src/read.ts
@@ -1,0 +1,76 @@
+import {
+  Page,
+  Block,
+  Backlink,
+  SearchResult,
+  Result
+} from '@logseq/model';
+import { NotFoundError } from './errors.js';
+
+export interface Indices {
+  pageByTitle: Map<string, Page>;
+  blocksById: Map<string, Block>;
+  childrenByParent: Map<string, string[]>;
+  backlinks: Map<string, Backlink[]>;
+}
+
+function ok<T>(value: T): Result<T> {
+  return { ok: true, value };
+}
+
+function notFound(msg: string): Result<never> {
+  return { ok: false, error: new NotFoundError(msg) };
+}
+
+export class InMemoryFileCore {
+  constructor(private idx: Indices) {}
+
+  getPage(id: string): Result<Page> {
+    const p = this.idx.pageByTitle.get(id);
+    return p ? ok(p) : notFound(`page ${id} not found`);
+    }
+
+  getPageByTitle(title: string): Result<Page> {
+    return this.getPage(title);
+  }
+
+  listPages(): Result<Page[]> {
+    return ok(Array.from(this.idx.pageByTitle.values()));
+  }
+
+  getBlock(id: string): Result<Block> {
+    const b = this.idx.blocksById.get(id);
+    return b ? ok(b) : notFound(`block ${id} not found`);
+  }
+
+  listBlocksByPage(pageId: string): Result<Block[]> {
+    const ids = this.idx.childrenByParent.get(`page:${pageId}`) || [];
+    return ok(ids.map(id => this.idx.blocksById.get(id)!).filter(Boolean));
+  }
+
+  listChildren(parentId: string): Result<Block[]> {
+    const ids = this.idx.childrenByParent.get(parentId) || [];
+    return ok(ids.map(id => this.idx.blocksById.get(id)!).filter(Boolean));
+  }
+
+  listLinksToPage(title: string): Result<Backlink[]> {
+    return ok(this.idx.backlinks.get(`page:${title}`) || []);
+  }
+
+  listLinksToBlock(id: string): Result<Backlink[]> {
+    return ok(this.idx.backlinks.get(`block:${id}`) || []);
+  }
+
+  search(q: string): Result<SearchResult> {
+    const query = q.toLowerCase();
+    const pages = Array.from(this.idx.pageByTitle.values()).filter(p =>
+      p.title.toLowerCase().includes(query)
+    );
+    const blocks = Array.from(this.idx.blocksById.values()).filter(b =>
+      b.text.toLowerCase().includes(query)
+    );
+    return ok({ pages, blocks });
+  }
+}
+
+export type FileCore = InMemoryFileCore;

--- a/packages/file-core/src/watch.ts
+++ b/packages/file-core/src/watch.ts
@@ -1,0 +1,5 @@
+import type { FsAdapter, WatchHandler } from '@logseq/fs-adapter';
+
+export function watchGraph(adapter: FsAdapter, dir: string, handler: WatchHandler) {
+  return adapter.watch(dir, handler);
+}

--- a/packages/file-core/test/read.spec.ts
+++ b/packages/file-core/test/read.spec.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createFileCore } from '../src/index.js';
+import NodeFsAdapter from '@logseq/fs-adapter';
+import type { Page, Block } from '@logseq/model';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '../../../../tools/fixtures/graph-root');
+
+test('read api basics', async () => {
+  const core = await createFileCore(root, new NodeFsAdapter());
+  const pages = core.listPages();
+  assert.ok(pages.ok);
+  assert.deepEqual(pages.value.map((p: Page) => p.title).sort(), ['Alpha', 'Beta']);
+
+  const alpha = core.getPageByTitle('Alpha');
+  assert.ok(alpha.ok && alpha.value);
+
+  const blocksAlpha = core.listBlocksByPage('Alpha');
+  assert.ok(blocksAlpha.ok);
+  assert.equal(blocksAlpha.value[0].id, 'alpha-block');
+
+  const children = core.listChildren('alpha-block');
+  assert.ok(children.ok);
+  assert.equal(children.value.length, 1);
+  assert.equal(children.value[0].text, 'alpha child');
+
+  const linksToBeta = core.listLinksToPage('Beta');
+  assert.ok(linksToBeta.ok);
+  assert.equal(linksToBeta.value[0].sourcePage, 'Alpha');
+
+  const linksToAlphaBlock = core.listLinksToBlock('alpha-block');
+  assert.ok(linksToAlphaBlock.ok);
+  assert.equal(linksToAlphaBlock.value[0].sourcePage, 'Beta');
+
+  const searchRes = core.search('child');
+  assert.ok(searchRes.ok);
+  assert.ok(searchRes.value.blocks.some((b: Block) => b.text.includes('child')));
+});

--- a/packages/file-core/tsconfig.json
+++ b/packages/file-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/fs-adapter/package.json
+++ b/packages/fs-adapter/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@logseq/fs-adapter",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "dist/node.js",
+  "types": "dist/node.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/node.js",
+      "types": "./dist/node.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "echo fs-adapter test ok"
+  },
+  "dependencies": {
+    "@logseq/model": "workspace:*"
+  }
+}

--- a/packages/fs-adapter/src/node.ts
+++ b/packages/fs-adapter/src/node.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { FsAdapter, WatchHandler, FileStats, WatchEvent } from './types.js';
+
+export class NodeFsAdapter implements FsAdapter {
+  async listFiles(dir: string): Promise<string[]> {
+    const entries = await fsp.readdir(dir);
+    return entries.map(e => path.join(dir, e));
+  }
+
+  async readFile(filePath: string): Promise<string> {
+    return await fsp.readFile(filePath, 'utf8');
+  }
+
+  async stat(filePath: string): Promise<FileStats> {
+    const s = await fsp.stat(filePath);
+    return { mtimeMs: s.mtimeMs };
+  }
+
+  async watch(dir: string, handler: WatchHandler): Promise<() => void> {
+    const watcher = fs.watch(dir, (event, filename) => {
+      if (!filename) return;
+      const evt: WatchEvent = event === 'rename' ? 'change' : event;
+      handler(evt, path.join(dir, filename.toString()));
+    });
+    return () => watcher.close();
+  }
+}
+
+export default NodeFsAdapter;
+export type { FsAdapter, WatchHandler } from './types.js';

--- a/packages/fs-adapter/src/types.ts
+++ b/packages/fs-adapter/src/types.ts
@@ -1,0 +1,13 @@
+export type WatchEvent = 'add' | 'change' | 'unlink';
+export type WatchHandler = (event: WatchEvent, path: string) => void;
+
+export interface FileStats {
+  mtimeMs: number;
+}
+
+export interface FsAdapter {
+  listFiles(dir: string): Promise<string[]>;
+  readFile(path: string): Promise<string>;
+  stat(path: string): Promise<FileStats>;
+  watch(dir: string, handler: WatchHandler): Promise<() => void>;
+}

--- a/packages/fs-adapter/tsconfig.json
+++ b/packages/fs-adapter/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@logseq/model",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "echo model test ok"
+  }
+}

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './zod.js';

--- a/packages/model/src/types.ts
+++ b/packages/model/src/types.ts
@@ -1,0 +1,37 @@
+export interface Page {
+  id: string;
+  title: string;
+  path: string;
+}
+
+export interface LinkToPage {
+  type: 'page';
+  page: string;
+}
+
+export interface LinkToBlock {
+  type: 'block';
+  blockId: string;
+}
+
+export type Link = LinkToPage | LinkToBlock;
+
+export interface Block {
+  id: string;
+  pageId: string;
+  parentId: string | null;
+  text: string;
+  links: Link[];
+}
+
+export interface Backlink {
+  sourcePage: string;
+  sourceBlockId?: string;
+}
+
+export interface SearchResult {
+  pages: Page[];
+  blocks: Block[];
+}
+
+export type Result<T> = { ok: true; value: T } | { ok: false; error: Error };

--- a/packages/model/src/zod.ts
+++ b/packages/model/src/zod.ts
@@ -1,0 +1,4 @@
+// Minimal placeholder schemas used internally without runtime validation
+export const LinkSchema = {};
+export const BlockSchema = {};
+export const PageSchema = {};

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - apps/*
+  - packages/*
   - tools/*
-

--- a/tools/fixtures/graph-root/alpha.md
+++ b/tools/fixtures/graph-root/alpha.md
@@ -1,0 +1,4 @@
+title:: Alpha
+- id:: alpha-block
+  - alpha child
+- link to [[Beta]]

--- a/tools/fixtures/graph-root/beta.md
+++ b/tools/fixtures/graph-root/beta.md
@@ -1,0 +1,3 @@
+title:: Beta
+- id:: beta-block
+- reference to ((alpha-block))

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Node",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -13,4 +13,3 @@
   "include": [],
   "exclude": ["node_modules", "dist", "build"]
 }
-


### PR DESCRIPTION
## Summary
- add shared model types
- implement node fs adapter
- add file-core with markdown parser, indices, and read API
- cover read APIs with sample graph test

## Testing
- `pnpm --filter @logseq/file-core test`
- `pnpm -w build`
- `pnpm -w test`
- `pnpm -w lint`
- `pnpm -w typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c74499cc808325b6109bedecc3651a