### PR TITLE
feat: detect external edits and expose conflicts

### DIFF
--- a/PHASE.yml
+++ b/PHASE.yml
@@ -1,14 +1,11 @@
-phase: "05_WRITES_WAL"
+phase: "06_EXTERNAL_EDITS"
 allowed_paths:
   - PHASE.yml
   - tools/check_phase.mjs
   - .github/workflows/ci.yml
-  - packages/file-core/src/write.ts
-  - packages/file-core/src/tx.ts
-  - packages/file-core/src/wal.ts
-  - packages/file-core/src/serialize.ts
-  - packages/file-core/test/write.spec.ts
-  - packages/file-core/test/recovery.spec.ts
+  - packages/file-core/src/watch.ts
+  - packages/file-core/src/conflicts.ts
+  - packages/file-core/test/conflicts.spec.ts
 acceptance:
   - pnpm -w build
   - pnpm -w test

--- a/packages/file-core/src/conflicts.ts
+++ b/packages/file-core/src/conflicts.ts
@@ -1,0 +1,29 @@
+import { type ParsedData } from './parse.js';
+
+export interface BlockConflict {
+  id: string;
+  ours: string;
+  theirs: string;
+}
+
+export interface Conflict {
+  file: string;
+  blocks: BlockConflict[];
+}
+
+export function detectConflicts(ours: ParsedData, theirs: ParsedData): Conflict | null {
+  const map = new Map(ours.blocks.map(b => [b.id, b.text]));
+  const conflicts: BlockConflict[] = [];
+  for (const b of theirs.blocks) {
+    const prev = map.get(b.id);
+    if (prev !== undefined && prev !== b.text) {
+      conflicts.push({ id: b.id, ours: prev, theirs: b.text });
+    }
+  }
+  return conflicts.length ? { file: theirs.page.path, blocks: conflicts } : null;
+}
+
+/** Simple merge strategy: prefer "theirs" */
+export function merge(_ours: ParsedData, theirs: ParsedData): ParsedData {
+  return theirs;
+}

--- a/packages/file-core/src/watch.ts
+++ b/packages/file-core/src/watch.ts
@@ -1,5 +1,64 @@
-import type { FsAdapter, WatchHandler } from '@logseq/fs-adapter';
+import crypto from 'node:crypto';
+import type { FsAdapter, WatchEvent, Watcher } from '@logseq/fs-adapter';
+import { parseFile, type ParsedData } from './parse.js';
+import { detectConflicts, merge, type Conflict } from './conflicts.js';
 
-export function watchGraph(adapter: FsAdapter, dir: string, handler: WatchHandler) {
-  return adapter.watch(dir, handler);
+interface Fingerprint {
+  mtime: number;
+  size: number;
+  hash: string;
+}
+
+export interface WatchOptions {
+  initial?: Record<string, ParsedData>;
+  onUpdate?: (file: string, data: ParsedData) => void;
+  onConflict?: (conflict: Conflict) => void;
+}
+
+function calcFingerprint(content: string, stat: { mtimeMs: number; size: number }): Fingerprint {
+  const hash = crypto.createHash('sha1').update(content).digest('hex');
+  return { mtime: stat.mtimeMs, size: stat.size, hash };
+}
+
+export function watchGraph(adapter: FsAdapter, dir: string, opts: WatchOptions = {}): Watcher {
+  const fps = new Map<string, Fingerprint>();
+  const parsed = new Map<string, ParsedData>();
+
+  if (opts.initial) {
+    for (const [file, data] of Object.entries(opts.initial)) {
+      parsed.set(file, data);
+      fps.set(file, { mtime: 0, size: 0, hash: '' });
+    }
+  }
+
+  const handler = async (evt: WatchEvent) => {
+    if (evt.type !== 'change') return;
+    const file = evt.path;
+    const content = await adapter.readFile(file);
+    const stat = await adapter.stat(file);
+    const fp = calcFingerprint(content, stat as any);
+    const prev = fps.get(file);
+    if (prev && prev.mtime === fp.mtime && prev.size === fp.size && prev.hash === fp.hash) {
+      return;
+    }
+    const nextParsed = parseFile(file, content);
+    const prevParsed = parsed.get(file);
+    if (prevParsed) {
+      const conflict = detectConflicts(prevParsed, nextParsed);
+      if (conflict) {
+        opts.onConflict?.(conflict);
+        const merged = merge(prevParsed, nextParsed);
+        parsed.set(file, merged);
+        fps.set(file, fp);
+        opts.onUpdate?.(file, merged);
+        return;
+      }
+    }
+    parsed.set(file, nextParsed);
+    fps.set(file, fp);
+    opts.onUpdate?.(file, nextParsed);
+  };
+
+  const watcher = adapter.watch(dir, handler);
+  return watcher;
 }

--- a/packages/file-core/test/conflicts.spec.ts
+++ b/packages/file-core/test/conflicts.spec.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { watchGraph } from '../src/watch.js';
+import { parseFile } from '../src/parse.js';
+import type { FsAdapter, WatchHandler, Watcher } from '@logseq/fs-adapter';
+
+class FakeAdapter implements FsAdapter {
+  constructor(public files: Record<string, string>) {}
+  async readFile(path: string): Promise<string> {
+    return this.files[path];
+  }
+  async stat(path: string): Promise<{ mtimeMs: number; size: number }> {
+    const content = this.files[path];
+    return { mtimeMs: Date.now(), size: content.length };
+  }
+  watch(_dir: string, handler: WatchHandler): Watcher {
+    this.handler = handler;
+    return { close() {} };
+  }
+  handler?: WatchHandler;
+  async writeFile(path: string, content: string) {
+    this.files[path] = content;
+    this.handler?.({ type: 'change', path });
+  }
+}
+
+test('detects external edits and surfaces conflict', async () => {
+  const file = '/alpha.md';
+  const base = 'title:: Alpha\n- id:: a1 one';
+  const adapter = new FakeAdapter({ [file]: base });
+  const parsed = parseFile(file, base);
+  let conflict: any = null;
+  let updated: any = null;
+  watchGraph(adapter, '/', {
+    initial: { [file]: parsed },
+    onConflict: c => { conflict = c; },
+    onUpdate: (_f, data) => { updated = data; }
+  });
+
+  const theirs = 'title:: Alpha\n- id:: a1 two';
+  await adapter.writeFile(file, theirs);
+
+  assert.ok(conflict, 'conflict should be reported');
+  assert.equal(conflict.blocks[0].theirs, 'two');
+  assert.ok(updated); 
+  assert.equal(updated.blocks[0].text, 'two');
+});


### PR DESCRIPTION
## Summary
- watch for filesystem changes and parse updated files
- surface block-level conflicts with simple merge strategy
- add tests ensuring external edits are detected

## Testing
- `node tools/check_phase.mjs`
- `pnpm -w build`
- `pnpm -w lint`
- `pnpm -w test`
- `pnpm -w typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c82f6dc008832597c88cf41ebb4015